### PR TITLE
Should fix the issue with karma and failed line numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,10 +79,10 @@
     "webpack": "^2.5.1"
   },
   "devDependencies": {
+    "assertions-counter": "^0.0.1",
+    "aurelia-protractor-plugin": "1.0.3",
     "aurelia-testing": "1.0.0-beta.3.0.1",
     "aurelia-tools": "1.0.0",
-    "aurelia-protractor-plugin": "1.0.3",
-    "assertions-counter": "^0.0.1",
     "babel-eslint": "7.2.3",
     "babel-plugin-istanbul": "4.1.3",
     "eslint": "^3.19.0",
@@ -96,6 +96,7 @@
     "karma-coverage-istanbul-reporter": "1.2.0",
     "karma-jasmine": "^1.1.0",
     "karma-mocha-reporter": "^2.2.3",
+    "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "2.0.3",
     "protractor": "5.1.1",
     "stylelint": "^7.8.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -28,7 +28,7 @@ module.exports = function (config) {
     * available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     */
     preprocessors: {
-      'test/karma-bundle.js': [ 'webpack' ]
+      'test/karma-bundle.js': [ 'webpack', 'sourcemap' ]
     },
 
     webpack: require('../webpack.config')({ coverage: true }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,7 @@ module.exports = ({production, server, extractCss, coverage} = {}) => ({
     historyApiFallback: true,
     port: parseInt(process.env.PORT, 10)
   },
+  devtool: (process.env.NODE_ENV !== 'production') ? 'inline-source-map' : false,
   // server: {port: parseInt(process.env.PORT, 10)},
   module: {
     rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4324,6 +4324,12 @@ karma-mocha-reporter@^2.2.3:
   dependencies:
     chalk "1.1.3"
 
+karma-sourcemap-loader@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz#91322c77f8f13d46fed062b042e1009d4c4505d8"
+  dependencies:
+    graceful-fs "^4.1.2"
+
 karma-webpack@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-2.0.3.tgz#39cebf5ca2580139b27f9ae69b78816b9c82fae6"
@@ -7241,16 +7247,9 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@1.1.2:
+ws@1.1.2, ws@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.2.tgz#8a244fa052401e08c9886cf44a85189e1fd4067f"
-  dependencies:
-    options ">=0.0.5"
-    ultron "1.0.x"
-
-ws@^1.0.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"


### PR DESCRIPTION
You'll see both the original spec file line number (done with `webpack://file.spec.js`) and the bundle line number locations.

Example:
<img width="759" alt="screen shot 2017-05-17 at 9 37 43 pm" src="https://cloud.githubusercontent.com/assets/723420/26182901/4875e468-3b49-11e7-9e4f-56e4127328da.png">
